### PR TITLE
Fix out of index error in mariadb_client

### DIFF
--- a/mariadb_kernel/mariadb_client.py
+++ b/mariadb_kernel/mariadb_client.py
@@ -25,7 +25,9 @@ class MariaREPL(replwrap.REPLWrapper):
         self._expect_prompt(timeout, async_)
 
         lines = self.child.before.split("\r\n")
-        result = lines[1]
+        result = lines[0]
+        if len(lines) > 1:
+            result = lines[1]
 
         return result
 


### PR DESCRIPTION
MariaREPL might not return multiple lines from `run_command`, only results set to the second line if the length is > 1.

Specifically this is the error this PR solves:
```
[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "/home/seth/.local/lib/python3.7/site-packages/ipykernel-5.3.1-py3.7.egg/ipykernel/kernelbase.py", line 268, in dispatch_shell
    yield gen.maybe_future(handler(stream, idents, msg))
  File "/home/seth/.local/lib/python3.7/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/home/seth/.local/lib/python3.7/site-packages/tornado/gen.py", line 209, in wrapper
    yielded = next(result)
  File "/home/seth/.local/lib/python3.7/site-packages/ipykernel-5.3.1-py3.7.egg/ipykernel/kernelbase.py", line 545, in execute_request
    user_expressions, allow_stdin,
  File "/home/seth/git/mariadb_kernel/mariadb_kernel/kernel.py", line 81, in do_execute
    result = self.mariadb_client.run_statement(s)
  File "/home/seth/git/mariadb_kernel/mariadb_kernel/mariadb_client.py", line 101, in run_statement
    result = self.maria_repl.run_command(code, timeout)
  File "/home/seth/git/mariadb_kernel/mariadb_kernel/mariadb_client.py", line 28, in run_command
    result = lines[1]
IndexError: list index out of range
```

I have previously signed the MCA.