### PR TITLE
Display a confirmation message for successful empty-result queries

### DIFF
--- a/mariadb_kernel/kernel.py
+++ b/mariadb_kernel/kernel.py
@@ -121,13 +121,26 @@ class MariaDBKernel(Kernel):
                 continue
 
             self._update_data(result)
-
-            display_content = {
-                "data": {"text/html": self._styled_result(result)},
-                "metadata": {},
-            }
+            result_str = str(result)
             if not silent:
-                self.send_response(self.iopub_socket, "display_data", display_content)
+                if (
+                    not result_str
+                ):  # empty result set, should, show success info to user
+                    display_content = {
+                        "data": {"text/plain": "Query OK"},
+                        "metadata": {},
+                    }
+                    self.send_response(
+                        self.iopub_socket, "display_data", display_content
+                    )
+                else:
+                    display_content = {
+                        "data": {"text/html": result_str},
+                        "metadata": {},
+                    }
+                    self.send_response(
+                        self.iopub_socket, "display_data", display_content
+                    )
 
         self._execute_magics(parser.get_magics())
 

--- a/mariadb_kernel/kernel.py
+++ b/mariadb_kernel/kernel.py
@@ -139,7 +139,9 @@ class MariaDBKernel(Kernel):
                         "metadata": {},
                     }
                     self.send_response(
-                        self.iopub_socket, "display_data", display_content
+                        self.iopub_socket,
+                        "display_data",
+                        self._styled_result(display_content),
                     )
 
         self._execute_magics(parser.get_magics())

--- a/mariadb_kernel/kernel.py
+++ b/mariadb_kernel/kernel.py
@@ -123,26 +123,11 @@ class MariaDBKernel(Kernel):
             self._update_data(result)
             result_str = str(result)
             if not silent:
-                if (
-                    not result_str
-                ):  # empty result set, should, show success info to user
-                    display_content = {
-                        "data": {"text/plain": "Query OK"},
-                        "metadata": {},
-                    }
-                    self.send_response(
-                        self.iopub_socket, "display_data", display_content
-                    )
-                else:
-                    display_content = {
-                        "data": {"text/html": result_str},
-                        "metadata": {},
-                    }
-                    self.send_response(
-                        self.iopub_socket,
-                        "display_data",
-                        self._styled_result(display_content),
-                    )
+                display_content = {
+                    "data": {"text/html": self._styled_result(result_str)},
+                    "metadata": {},
+                }
+                self.send_response(self.iopub_socket, "display_data", display_content)
 
         self._execute_magics(parser.get_magics())
 

--- a/mariadb_kernel/mariadb_client.py
+++ b/mariadb_kernel/mariadb_client.py
@@ -147,6 +147,8 @@ class MariaDBClient:
             self.errormsg = result
         else:
             self.error = False
+        if not result:
+            result = "Query OK"
 
         return result
 

--- a/mariadb_kernel/tests/test_mariadbclient.py
+++ b/mariadb_kernel/tests/test_mariadbclient.py
@@ -80,3 +80,9 @@ def test_mariadb_client_run_statement(mariadb_server):
     assert client.iserror()
 
     assert result == client.error_message()
+
+    client.run_statement("create database if not exists test;")
+
+    result = client.run_statement("use test;")
+
+    assert result == "Query OK"


### PR DESCRIPTION
related to https://github.com/MariaDB/mariadb_kernel/issues/15

## my ideas :
mariadb_kernel/kernel.py is reponsible for execute the code when frontend run a cell, and the function handle this is `do_execute(...)`，which would parse sql and magic command and execute it.  The following code for execute sql statements.
```python
 # part of mariadb\_kernel/kernel.py
 statements = parser.get_sql()
 for s in statements:
	 result = self.mariadb_client.run_statement(s)
	 if self.mariadb_client.iserror():
	 	self._send_message("stderr", self.mariadb\_client.error\_message())
	 	continue
 	self._update_data(result)
 	display_content = {"data": {"text/html": str(result)}, "metadata": {}}
 	if not silent:
 		self.send_response(self.iopub_socket, "display_data", display_content)

```
when error occur, `if self.mariadb_client.iserror():` will handle this. After that, if the result is empty we should display a pure text, show ''Query OK", make the user assure execution success

## demonstration(video)
https://www.youtube.com/watch?v=-3GKlLQjwGA&ab_channel=%E6%B1%9F%E6%96%B0%E7%9F%A5