### PR TITLE
 @jonakarl Simplify users first time experience 

### DIFF
--- a/mariadb_kernel/client_config.py
+++ b/mariadb_kernel/client_config.py
@@ -14,11 +14,20 @@ class ClientConfig:
         self.default_config = {
             "user": "root",
             "host": "localhost",
+            "socket": "/tmp/mysqld.sock",
             "port": "3306",
             "password": "",
             "start_server": "True",
             "client_bin": "mysql",
             "server_bin": "mysqld",
+            "db_init_bin": "mysql_install_db",
+            "extra_server_config": ["--pid-file=/tmp/mysqld.pid",
+                                    f"--datadir={os.path.join(os.environ.get('HOME'), 'work', '.db')}",
+                                    "--skip_log_error"],
+            "extra_db_init_config": [f"--user={os.environ.get('NB_USER')}",
+                                     "--auth-root-authentication-method=normal",
+                                     "--skip-test-db",
+                                     "--rpm"]
         }
 
         self._load_config()
@@ -56,7 +65,7 @@ class ClientConfig:
             using_default = True
 
         if using_default:
-            self.log.info(f"Using default config: {self.default_config}")
+            self.log.info(f"Using default config: {json.dumps(self.default_config, indent=4)}")
             return
 
         self.default_config.update(cfg)
@@ -70,10 +79,26 @@ class ClientConfig:
 
     def get_args(self):
         rv = ""
-        keys = ["user", "host", "port", "password"]
+        keys = ["user", "host", "port", "password", "socket"]
         for key in keys:
             value = self.default_config[key]
             rv += f"--{key}={value} "
+        return rv
+
+    def get_server_args(self):
+        rv = []
+        rv.extend(self.default_config["extra_server_config"])
+        # get_args return a string and we need it as a list
+        # we also do not want user as sql user might differ from exec user
+        rv.append(f"--socket={self.default_config['socket']}")
+        rv.append(f"--port={self.default_config['port']}")
+        rv.append(f"--bind-address={self.default_config['host']}")
+        return rv
+
+    def get_init_args(self):
+        rv = []
+        rv.extend(self.get_server_args())
+        rv.extend(self.default_config["extra_db_init_config"])
         return rv
 
     def start_server(self):
@@ -84,3 +109,6 @@ class ClientConfig:
 
     def server_bin(self):
         return self.default_config["server_bin"]
+
+    def db_init_bin(self):
+        return self.default_config["db_init_bin"]

--- a/mariadb_kernel/client_config.py
+++ b/mariadb_kernel/client_config.py
@@ -13,23 +13,26 @@ class ClientConfig:
         self.config_name = name
 
         datadir = "/tmp/mariadb_kernel/datadir"
+        pidfile = "/tmp/mariadb_kernel/mysqld.pid"
+        socketfile = "/tmp/mariadb_kernel/mysqld.sock"
+
         if "NB_USER" in os.environ:
             datadir = os.path.join("/home/", os.environ["NB_USER"], "work", ".db")
 
         self.default_config = {
             "user": "root",
             "host": "localhost",
-            "socket": "/tmp/mysqld.sock",
+            "socket": socketfile,
             "port": "3306",
             "password": "",
-            "datadir": datadir,  # Server specific option
+            "server_datadir": datadir,  # Server specific option
+            "server_pid": pidfile,  # Server specific option
             "start_server": "True",
             "client_bin": "mysql",
             "server_bin": "mysqld",
             "db_init_bin": "mysql_install_db",
             "extra_server_config": [
                 "--no-defaults",
-                "--pid-file=/tmp/mysqld.pid",
                 "--skip_log_error",
             ],
             "extra_db_init_config": [
@@ -102,7 +105,8 @@ class ClientConfig:
         rv.append(f"--port={self.default_config['port']}")
         rv.append(f"--bind-address={self.default_config['host']}")
         # Server specific config
-        rv.append(f"--datadir={self.default_config['datadir']}")
+        rv.append(f"--datadir={self.default_config['server_datadir']}")
+        rv.append(f"--pid-file={self.default_config['server_pid']}")
         return rv
 
     def get_init_args(self):
@@ -110,6 +114,13 @@ class ClientConfig:
         rv.extend(self.get_server_args())
         rv.extend(self.default_config["extra_db_init_config"])
         return rv
+
+    def get_server_paths(self):
+        return [
+            os.path.dirname(self.default_config["socket"]),
+            os.path.dirname(self.default_config["server_datadir"]),
+            os.path.dirname(self.default_config["server_pid"]),
+        ]
 
     def start_server(self):
         return self.default_config["start_server"] == "True"

--- a/mariadb_kernel/client_config.py
+++ b/mariadb_kernel/client_config.py
@@ -22,9 +22,9 @@ class ClientConfig:
             "server_bin": "mysqld",
             "db_init_bin": "mysql_install_db",
             "extra_server_config": ["--pid-file=/tmp/mysqld.pid",
-                                    f"--datadir={os.path.join(os.environ.get('HOME'), 'work', '.db')}",
+                                    f"--datadir={os.path.join(os.environ.get('HOME', '/home/jovyan/'), 'work', '.db')}",
                                     "--skip_log_error"],
-            "extra_db_init_config": [f"--user={os.environ.get('NB_USER')}",
+            "extra_db_init_config": [f"--user={os.environ.get('NB_USER', 'jovyan')}",
                                      "--auth-root-authentication-method=normal",
                                      "--skip-test-db",
                                      "--rpm"]

--- a/mariadb_kernel/client_config.py
+++ b/mariadb_kernel/client_config.py
@@ -21,13 +21,17 @@ class ClientConfig:
             "client_bin": "mysql",
             "server_bin": "mysqld",
             "db_init_bin": "mysql_install_db",
-            "extra_server_config": ["--pid-file=/tmp/mysqld.pid",
-                                    f"--datadir={os.path.join(os.environ.get('HOME', '/home/jovyan/'), 'work', '.db')}",
-                                    "--skip_log_error"],
-            "extra_db_init_config": [f"--user={os.environ.get('NB_USER', 'jovyan')}",
-                                     "--auth-root-authentication-method=normal",
-                                     "--skip-test-db",
-                                     "--rpm"]
+            "extra_server_config": [
+                "--pid-file=/tmp/mysqld.pid",
+                f"--datadir={os.path.join(os.environ.get('HOME', '/home/jovyan/'), 'work', '.db')}",
+                "--skip_log_error",
+            ],
+            "extra_db_init_config": [
+                f"--user={os.environ.get('NB_USER', 'jovyan')}",
+                "--auth-root-authentication-method=normal",
+                "--skip-test-db",
+                "--rpm",
+            ],
         }
 
         self._load_config()
@@ -65,7 +69,9 @@ class ClientConfig:
             using_default = True
 
         if using_default:
-            self.log.info(f"Using default config: {json.dumps(self.default_config, indent=4)}")
+            self.log.info(
+                f"Using default config: {json.dumps(self.default_config, indent=4)}"
+            )
             return
 
         self.default_config.update(cfg)

--- a/mariadb_kernel/kernel.py
+++ b/mariadb_kernel/kernel.py
@@ -143,7 +143,7 @@ class MariaDBKernel(Kernel):
 
     def do_shutdown(self, restart):
         self.mariadb_client.stop()
-        if self.mariadb_server:
+        if self.mariadb_server and self.mariadb_server.is_up():
             self.mariadb_server.stop()
 
     def do_complete(self, code, cursor_pos):

--- a/mariadb_kernel/mariadb_server.py
+++ b/mariadb_kernel/mariadb_server.py
@@ -54,7 +54,7 @@ class MariaDBServer:
             self.log.info("Started MariaDB server successfully")
         else:
             self.log.error("MariaDB server did NOT start successfully")
-    
+
     def init_db(self):
         server_bin = self.config.db_init_bin()
         args = self.config.get_init_args()

--- a/mariadb_kernel/mariadb_server.py
+++ b/mariadb_kernel/mariadb_server.py
@@ -50,8 +50,11 @@ class MariaDBServer:
 
         msg = f"{self.server_name}: ready for connections"
         self._wait_server(self.server.stderr, msg)
-        self.log.info("Started MariaDB server successfully")
-
+        if self.is_up():
+            self.log.info("Started MariaDB server successfully")
+        else:
+            self.log.error("MariaDB server did NOT start successfully")
+    
     def init_db(self):
         server_bin = self.config.db_init_bin()
         args = self.config.get_init_args()
@@ -79,7 +82,7 @@ class MariaDBServer:
     def _wait_server(self, stream, msg):
         while self.is_up():
             line = stream.readline().rstrip()
-            self.log.info(line)
+            self.log.debug(line)
             if msg in line:
                 return
 

--- a/mariadb_kernel/mariadb_server.py
+++ b/mariadb_kernel/mariadb_server.py
@@ -11,7 +11,7 @@ tries to spin a new instance for testing purposes and issues a warning.
 
 import subprocess
 import signal
-import time
+import os
 
 
 class MariaDBServer:
@@ -30,6 +30,9 @@ class MariaDBServer:
         cmd = []
         cmd.append(server_bin)
         cmd.extend(args)
+        # Create paths needed for pid/socket and datadir
+        for path in self.config.get_server_paths():
+            os.makedirs(path, exist_ok=True)
         try:
             self.init_db()
             self.server = subprocess.Popen(


### PR DESCRIPTION
Changes:
- Call mysql_db_install to install a empty database with socket authentication for the root user
- Modify run-time options for mysqld so it can server created database
- Add socket authentication as a client connect option
- Added log messages for mysql_db_install and mysqld
- is_up() is now dependant on the status of the mysqld process status

TODO:
- Lookup why I need to pass --auth-root-authentication-method=normal to get socket auth to work with root user
- revise the --rpm flag (removes some warnings but might be a unstable hack)
- Does NB_USER and HOME shell variables always exist?
  - Only tested using jupyter/datascience-notebook:hub-1.1.0 where they always exist
- If opening multiple nooteboks, only close mysqld when the last notebook is closed.