### PR TITLE
Make server name configurable.

### DIFF
--- a/mariadb_kernel/client_config.py
+++ b/mariadb_kernel/client_config.py
@@ -30,6 +30,7 @@ class ClientConfig:
             "start_server": "True",
             "client_bin": "mysql",
             "server_bin": "mysqld",
+            "server_name": "MariaDB",
             "db_init_bin": "mysql_install_db",
             "extra_server_config": [
                 "--no-defaults",
@@ -147,3 +148,6 @@ class ClientConfig:
 
     def autocompletion_enabled(self):
         return self.default_config["code_completion"] == "True"
+
+    def server_name(self):
+        return self.default_config["server_name"]

--- a/mariadb_kernel/mariadb_client.py
+++ b/mariadb_kernel/mariadb_client.py
@@ -49,7 +49,7 @@ class MariaDBClient:
         args = config.get_args()
         self.cmd = f"{self.client_bin} {kernel_args} {args}"
 
-        self.prompt = re.compile(r"MariaDB \[.*\]>[ \t]")
+        self.prompt = re.compile(config.server_name() + r" \[.*\]>[ \t]")
         self.log = log
         self.error = False
         self.errormsg = ""

--- a/mariadb_kernel/tests/test_mariadbclient.py
+++ b/mariadb_kernel/tests/test_mariadbclient.py
@@ -16,6 +16,7 @@ def test_mariadb_client_logs_error_when_clienbin_invalid():
     mockconfig = Mock()
     client_bin = "invalid_mysql"
     mockconfig.client_bin.return_value = client_bin
+    mockconfig.server_name.return_value = "MariaDB"
 
     client = MariaDBClient(mocklog, mockconfig)
     client.start()
@@ -32,6 +33,7 @@ def test_mariadb_client_raises_when_server_is_down():
     # Give the client a wrong port, simulate that MariaDB Server is down
     mockconfig.client_bin.return_value = "mysql"
     mockconfig.get_args.return_value = "--port=0000"
+    mockconfig.server_name.return_value = "MariaDB"
 
     client = MariaDBClient(mocklog, mockconfig)
 


### PR DESCRIPTION
At this time, only MariaDB servers are recognized. This change makes it possible to connect to other MySQL compatible servers as well.
