### PR TITLE
add Dockerfile, fixes #36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jupyter/scipy-notebook
+USER root
+
+RUN apt update
+RUN apt install -y mariadb-server
+RUN pip install mariadb_kernel
+RUN python3 -m mariadb_kernel.install


### PR DESCRIPTION
this request adds a Dockerfile specifying a basic setup of Jupyter including mariadb_kernel, as suggested in #36.
i currently build and run this as:

```sh
docker build -t mariadb_kernel . && docker run -p 8888:8888 --rm -v $(pwd):/home/jovyan/work --name mariadb_kernel mariadb_kernel
```

we may need a few tweaks to the file if we'd rather not have it use root user.

once we could get a working Dockerfile in and an image published to Docker Hub, perhaps we could include such usage instructions based on the published image.
