### PR TITLE
allow configuring column separator in %load, fixes #43

### DIFF
--- a/mariadb_kernel/maria_magics/load.py
+++ b/mariadb_kernel/maria_magics/load.py
@@ -2,13 +2,19 @@
 
 help_text = """
 The %load magic command has the following syntax:
-    > %load csv_file_path table_name [skip_row_num]
+    > %load csv_file_path table_name [skip_row_num] [seperator] [character set] [enclosing character]
 The %load magic command can load CSV file for updating specific table data.
 
 This command does not create a table if the one specified as argument doesn't exist,
 the user needs to create the destination table with the proper schema to match the data in the CSV file.
 
 CSV file first line may be header, can set [skip row num] to 1 for skipping header.
+
+The separator between columns defaults to ',', but can be reconfigured.
+
+The character set used by the CSV file defaults to utf8.
+
+The character used to enclose entries to escape the field delimiter defaults to `"`.
 
 Any argument can be enclosed by ' ' or " ", handling cases that argument contains spaces.
 """
@@ -29,6 +35,9 @@ class Load(LineMagic):
 
     def execute(self, kernel, data):
         self.skip_row_num = 0
+        self.character_set = 'utf8'
+        self.separator = ','
+        self.encloser = '"'
 
         if len(self.args_list) < 2:
             kernel._send_message(
@@ -41,12 +50,20 @@ class Load(LineMagic):
             self.csv_file_path = self.args_list[0]
             self.table_name = self.args_list[1]
             if len(self.args_list) > 2:
-                self.skip_row_num = int(self.args_list[3])
+                self.skip_row_num = int(self.args_list[2])
+                if len(self.args_list) > 3:
+                    self.separator = self.args_list[3]
+                    if len(self.args_list) > 4:
+                        self.character_set = self.args_list[4]
+                        if len(self.args_list) > 5:
+                            self.encloser = self.args_list[5]
 
         use_csv_update_table_cmd = f"""LOAD DATA LOCAL INFILE '{self.csv_file_path}'
                        IGNORE
                        INTO TABLE {self.table_name}
-                       FIELDS TERMINATED BY ','
+                       CHARACTER SET {self.character_set}
+                       FIELDS TERMINATED BY '{self.separator}'
+                       ENCLOSED BY '{self.encloser}'
                        IGNORE {self.skip_row_num} LINES
                        ;"""
         kernel.mariadb_client.run_statement(use_csv_update_table_cmd)


### PR DESCRIPTION
this PR adds an additional parameter to `%load`, to allow importing CSVs using different delimiters, addressing #43.

additionally, this fixes a bug where the `%load` parameters previously had a gap, although this fix constitutes a breaking change.
